### PR TITLE
Don't free Future until observers are done

### DIFF
--- a/Tests/FateTests/FateTests.swift
+++ b/Tests/FateTests/FateTests.swift
@@ -1,15 +1,26 @@
 import XCTest
-@testable import Fate
+import Fate
 
 final class FateTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual(true, true)
+    func someFuture() -> Future<Void, Error> {
+        let promise = Promise<Void, Error>()
+        DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + 2) {
+            try! promise.resolve(with: ())
+        }
+        return promise
+    }
+
+    func testCancel() {
+        let future = someFuture()
+        future.observe { (result) in
+            fatalError("Oh, man the observe got executed and it shouldn't have")
+        }
+        future.cancel()
+
+        sleep(5)
     }
 
     static var allTests = [
-        ("testExample", testExample),
+        ("testCancel", testCancel),
     ]
 }


### PR DESCRIPTION
The goal of this change is to make it so that the Future object won't
get freed until the observe callbacks are finished executing.

This is useful when you have code as follows that gets a future within
the scope of a method, because when the scope of `someFunc()` ends
`future` is freed. This can cause race conditions with the `didSet`
property observer in the Future implementation.

```
func someFunc() {
  let future = somethingThatReturnsAFuture()
  future.observe(with: { result in
    // Do stuff
  }
}
```

This can of course be worked around in the client app by capturing a
strong reference to `future` inside of the observe callback as follows.

```
func someFunc() {
  let future = somethingThatReturnsAFuture()
  future.observe(with: { result in
    let _ = future // capture, creating strong reference
    // Do stuff
  }
}
```

Creating that strong reference in the scope of the observe callback
closure makes it so that `future` can't be freed at least until the
observe callback is complete.

I have taken a very similar approach inside of `observe` method's
implementation by creating a wrapping closure that simply captures a
strong reference to `self` and then executes the observe callback. Which
should make sure the future, in this case `self`, isn't freed at least
until all the observe callbacks have completed.

I think this is a better solution than forcing consuming application
developers to have to worry about managing the lifetime of the future
instance using hackery like above but all across their application.

I don't see any real downsides to doing this either. Though it is always
possible I missed something.